### PR TITLE
feat: testing anthropic version

### DIFF
--- a/.github/workflows/redrover_review.yml
+++ b/.github/workflows/redrover_review.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Read file
         id: file
         run: echo "::set-output name=content::$(cat red_rover/custom_prompt.txt)"
-      - uses: RedVentures/red-rover@anthropic-alpha-1
+      - uses: RedVentures/red-rover@anthropic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/redrover_review.yml
+++ b/.github/workflows/redrover_review.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Read file
         id: file
         run: echo "::set-output name=content::$(cat red_rover/custom_prompt.txt)"
-      - uses: ./
+      - uses: RedVentures/red-rover@anthropic-alpha-1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/redrover_review.yml
+++ b/.github/workflows/redrover_review.yml
@@ -28,14 +28,13 @@ jobs:
       - uses: ./
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          debug: false
+          debug: true
           poem_enabled: true
           less_verbose_review: false
           review_comment_lgtm: false
-          openai_heavy_model: gpt-4
           path_filters: |
             !dist/**
             !**/*.lock
-          system_message: ${{ steps.file.outputs.content }}   
+          # system_message: ${{ steps.file.outputs.content }}   

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ The MIT License (MIT)
 
 Copyright (c) 2023 FluxNinja, Inc.
 Copyright (c) 2023 Tao He
+Copyright (c) 2023 tmokmss
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 <h1><img align="center" height="60" src="https://github.com/user-attachments/assets/84111c2e-fe44-4de1-b82d-45f38199724a">  &nbsp;&nbsp;Red Rover</h1>
 
-<br/>
-
-## Overview
+### Overview
 
 RedRover is an AI-based code reviewer and summarizer for
 GitHub pull requests using Anthropic models. It is
 designed to be used as a GitHub Action and can be configured to run on every
 pull request and review comments
 
-## Reviewer Features:
+To use this tool, you need to add the provided YAML file to your repository and
+configure the required environment variables, such as `GITHUB_TOKEN` and
+`ANTHROPIC_API_KEY`. For more information on usage, examples, and development
+you can refer to the sections below.
+
+### Reviewer Features:
 
 - **PR Summarization**: It generates a summary and release notes of the changes
   in the pull request.
@@ -37,18 +40,6 @@ pull request and review comments
 - **Customizable prompts**: Tailor the `system_message`, `summarize`, and
   `summarize_release_notes` prompts to focus on specific aspects of the review
   process or even change the review objective.
-
-To use this tool, you need to add the provided YAML file to your repository and
-configure the required environment variables, such as `GITHUB_TOKEN` and
-`ANTHROPIC_API_KEY`. For more information on usage, examples, and development
-you can refer to the sections below.
-
-- [Overview](#overview)
-- [Reviewer Features](#reviewer-features)
-- [Install instructions](#install-instructions)
-- [Conversation with RedRover(#conversation-with-RedRover)
-- [Examples](#examples)
-- [Developing](#developing)
 
 ## Install instructions
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# RedRover - An OpenAI ChatGPT-based PR reviewer and summarizer
+<h1><img align="center" height="60" src="https://github.com/user-attachments/assets/84111c2e-fe44-4de1-b82d-45f38199724a">  &nbsp;&nbsp;Red Rover</h1>
 
-![small-red-rover](https://github.com/bankrate/red-rover/assets/64108082/9ee5df3f-bc3f-4bfc-878e-171d7ccca96e)
+<br/>
 
 ## Overview
 
 RedRover is an AI-based code reviewer and summarizer for
-GitHub pull requests using OpenAI's `gpt-3.5-turbo` and `gpt-4` models. It is
+GitHub pull requests using Anthropic models. It is
 designed to be used as a GitHub Action and can be configured to run on every
 pull request and review comments
 
@@ -18,13 +18,11 @@ pull request and review comments
 - **Continuous, incremental reviews**: Reviews are performed on each commit
   within a pull request, rather than a one-time review on the entire pull
   request.
-- **Cost-effective and reduced noise**: Incremental reviews save on OpenAI costs
+- **Cost-effective and reduced noise**: Incremental reviews save on Anthropic costs
   and reduce noise by tracking changed files between commits and the base of the
   pull request.
 - **"Light" model for summary**: Designed to be used with a "light"
-  summarization model (e.g. `gpt-3.5-turbo`) and a "heavy" review model (e.g.
-  `gpt-4`). _For best results, use `gpt-4` as the "heavy" model, as thorough
-  code review needs strong reasoning abilities._
+  summarization model and a "heavy" review model.
 - **Chat with bot**: Supports conversation with the bot in the context of lines
   of code or entire files, useful for providing context, generating test cases,
   and reducing code complexity.
@@ -42,14 +40,13 @@ pull request and review comments
 
 To use this tool, you need to add the provided YAML file to your repository and
 configure the required environment variables, such as `GITHUB_TOKEN` and
-`OPENAI_API_KEY`. For more information on usage, examples, and development 
+`ANTHROPIC_API_KEY`. For more information on usage, examples, and development
 you can refer to the sections below.
 
 - [Overview](#overview)
-- [Professional Version of RedRover](#professional-version-of-RedRover)
 - [Reviewer Features](#reviewer-features)
 - [Install instructions](#install-instructions)
-- [Conversation with RedRover](#conversation-with-RedRover)
+- [Conversation with RedRover(#conversation-with-RedRover)
 - [Examples](#examples)
 - [Developing](#developing)
 
@@ -81,10 +78,10 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: RedVentures/red-rover@latest
+      - uses: RedVentures/red-rover@anthropic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
           debug: false
           review_simple_changes: false
@@ -95,22 +92,9 @@ jobs:
 
 - `GITHUB_TOKEN`: This should already be available to the GitHub Action
   environment. This is used to add comments to the pull request.
-- `OPENAI_API_KEY`: use this to authenticate with OpenAI API. You can get one
-  [here](https://platform.openai.com/account/api-keys). Please add this key to
+- `ANTHROPIC_API_KEY`: use this to authenticate with Anthropic API. You can get one
+  [here](https://console.anthropic.com/settings/keys). Please add this key to
   your GitHub Action secrets.
-- `OPENAI_API_ORG`: (optional) use this to use the specified organization with
-  OpenAI API if you have multiple. Please add this key to your GitHub Action
-  secrets.
-
-### Models: `gpt-4` and `gpt-3.5-turbo`
-
-Recommend using `gpt-3.5-turbo` for lighter tasks such as summarizing the
-changes (`openai_light_model` in configuration) and `gpt-4` for more complex
-review and commenting tasks (`openai_heavy_model` in configuration).
-
-Costs: `gpt-3.5-turbo` is dirt cheap. `gpt-4` is orders of magnitude more
-expensive, but the results are vastly superior. We are typically spending $20 a
-day for a 20 developer team with `gpt-4` based review and commenting.
 
 ### Prompts & Configuration
 
@@ -206,18 +190,7 @@ Build the typescript and package it for distribution
 $ npm run build && npm run package
 ```
 
-### Inspect the messages between OpenAI server
+### Inspect the messages between Anthropic server
 
 Set `debug: true` in the workflow file to enable debug mode, which will show the
 messages
-
-### Disclaimer
-
-- Your code (files, diff, PR title/description) will be sent to OpenAI's servers
-  for processing. Please check with your compliance team before using this on
-  your private code repositories.
-- OpenAI's API is used instead of ChatGPT session on their portal. OpenAI API
-  has a
-  [more conservative data usage policy](https://openai.com/policies/api-data-usage-policies)
-  compared to their ChatGPT offering.
-- This action is not affiliated with OpenAI.

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'AI-based PR Reviewer & Summarizer with Chat Capabilities'
 branding:
   icon: 'git-merge'
   color: 'orange'
-author: 'CodeRabbit LLC'
+author: 'gwilkes-rv'
 inputs:
   debug:
     required: false
@@ -148,35 +148,31 @@ inputs:
     required: false
     description: 'Disable release notes'
     default: 'false'
-  openai_base_url:
-    required: false
-    description: 'The url of the openai api interface.'
-    default: 'https://api.openai.com/v1'
-  openai_light_model:
+  anthropic_light_model:
     required: false
     description:
       'Model to use for simple tasks like summarizing diff on a file.'
-    default: 'gpt-4o-mini'
-  openai_heavy_model:
+    default: 'claude-3-haiku-20240307'
+  anthropic_heavy_model:
     required: false
     description: 'Model to use for complex tasks such as code reviews.'
-    default: 'gpt-4o'
-  openai_model_temperature:
+    default: 'claude-3-5-sonnet-20240620'
+  anthropic_model_temperature:
     required: false
     description: 'Temperature for GPT model'
     default: '0.05'
-  openai_retries:
+  anthropic_retries:
     required: false
     description:
-      'How many times to retry OpenAI API in case of timeouts or errors?'
+      'How many times to retry Anthropic API in case of timeouts or errors?'
     default: '5'
-  openai_timeout_ms:
+  anthropic_timeout_ms:
     required: false
-    description: 'Timeout for OpenAI API call in millis'
+    description: 'Timeout for Anthropic API call in millis'
     default: '360000'
-  openai_concurrency_limit:
+  anthropic_concurrency_limit:
     required: false
-    description: 'How many concurrent API calls to make to OpenAI servers?'
+    description: 'How many concurrent API calls to make to Anthropic servers?'
     default: '6'
   github_concurrency_limit:
     required: false
@@ -184,41 +180,34 @@ inputs:
     default: '6'
   system_message:
     required: false
-    description: 'System message to be sent to OpenAI'
+    description: 'System message to be sent to Anthropic'
     default: |
-      You are `@redrover` (aka `github-actions[bot]`), a language model
-      trained by OpenAI. Your purpose is to act as a highly experienced
-      software engineer and provide a thorough review of the code hunks
-      and suggest code snippets to improve key areas such as:
-        - Logic
-        - Security
-        - Performance
-        - Data races
-        - Consistency
-        - Error handling
-        - Maintainability
-        - Modularity
-        - Complexity
-        - Optimization
-        - Best practices: DRY, SOLID, KISS
+      You are `@redrover` (aka `github-actions[bot]`), a language model 
+      trained by Anthropic. Your purpose is to act as a highly experienced 
+      software engineer and provide a thorough review of the code, related documents, and articles
+      and suggest code snippets to improve these with various aspects.
 
-      Do not comment on minor code style issues, missing 
-      comments/documentation. Identify and resolve significant 
-      concerns to improve overall code quality while deliberately 
-      disregarding minor issues.
+      Follow the following instructions.
   summarize:
     required: false
     description: 'The prompt for final summarization response'
     default: |
       Provide your final response in markdown with the following content:
 
-      **Walkthrough**: A high-level summary of the overall change instead of 
-      specific files within 80 words.
-      **Changes**: A markdown table of files and their summaries. Group files 
-      with similar changes together into a single row to save space.
+      - **Walkthrough**: A high-level summary of the overall change instead of 
+        specific files within 80 words.
+      - **Changes**: A markdown table of files and their summaries. Group files 
+        with similar changes together into a single row to save space.
 
       Avoid additional commentary as this summary will be added as a comment on the 
       GitHub pull request. Use the titles "Walkthrough" and "Changes" and they must be H2.
+  review_file_diff:
+    required: false
+    description: 'The additional instruction for reviewing file diff'
+    default: |
+      - Do NOT provide general feedback, summaries, explanations of changes, or praises for making good additions. 
+      - Focus solely on offering specific, objective insights based on the given context and refrain from making broad comments about potential impacts on the system or question intentions behind the changes.
+
   summarize_release_notes:
     required: false
     description:
@@ -248,6 +237,10 @@ inputs:
     required: false
     description: ISO code for the response language
     default: en-US
+  bot_icon:
+    required: false
+    description: 'The icon for Red Rover'
+    default: 🐶
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -156,7 +156,7 @@ inputs:
   anthropic_heavy_model:
     required: false
     description: 'Model to use for complex tasks such as code reviews.'
-    default: 'claude-3-5-sonnet-20240620'
+    default: 'claude-3-5-sonnet-latest'
   anthropic_model_temperature:
     required: false
     description: 'Temperature for GPT model'

--- a/dist/37.index.js
+++ b/dist/37.index.js
@@ -10,7 +10,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "toFormData": () => (/* binding */ toFormData)
 /* harmony export */ });
-/* harmony import */ var fetch_blob_from_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(2777);
+/* harmony import */ var fetch_blob_from_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(7972);
 /* harmony import */ var formdata_polyfill_esm_min_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(8010);
 
 

--- a/dist/73.index.js
+++ b/dist/73.index.js
@@ -1,0 +1,129 @@
+"use strict";
+exports.id = 73;
+exports.ids = [73];
+exports.modules = {
+
+/***/ 4073:
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __webpack_require__) => {
+
+// ESM COMPAT FLAG
+__webpack_require__.r(__webpack_exports__);
+
+// EXPORTS
+__webpack_require__.d(__webpack_exports__, {
+  "fileFromPath": () => (/* binding */ fileFromPath),
+  "fileFromPathSync": () => (/* binding */ fileFromPathSync),
+  "isFile": () => (/* reexport */ isFile/* isFile */.z)
+});
+
+// EXTERNAL MODULE: external "fs"
+var external_fs_ = __webpack_require__(7147);
+// EXTERNAL MODULE: external "path"
+var external_path_ = __webpack_require__(1017);
+// EXTERNAL MODULE: ./node_modules/node-domexception/index.js
+var node_domexception = __webpack_require__(7760);
+// EXTERNAL MODULE: ./node_modules/formdata-node/lib/esm/File.js
+var File = __webpack_require__(2084);
+;// CONCATENATED MODULE: ./node_modules/formdata-node/lib/esm/isPlainObject.js
+const getType = (value) => (Object.prototype.toString.call(value).slice(8, -1).toLowerCase());
+function isPlainObject(value) {
+    if (getType(value) !== "object") {
+        return false;
+    }
+    const pp = Object.getPrototypeOf(value);
+    if (pp === null || pp === undefined) {
+        return true;
+    }
+    const Ctor = pp.constructor && pp.constructor.toString();
+    return Ctor === Object.toString();
+}
+/* harmony default export */ const esm_isPlainObject = (isPlainObject);
+
+// EXTERNAL MODULE: ./node_modules/formdata-node/lib/esm/isFile.js
+var isFile = __webpack_require__(1574);
+;// CONCATENATED MODULE: ./node_modules/formdata-node/lib/esm/fileFromPath.js
+var __classPrivateFieldSet = (undefined && undefined.__classPrivateFieldSet) || function (receiver, state, value, kind, f) {
+    if (kind === "m") throw new TypeError("Private method is not writable");
+    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+    return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
+};
+var __classPrivateFieldGet = (undefined && undefined.__classPrivateFieldGet) || function (receiver, state, kind, f) {
+    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+    return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+};
+var _FileFromPath_path, _FileFromPath_start;
+
+
+
+
+
+
+const MESSAGE = "The requested file could not be read, "
+    + "typically due to permission problems that have occurred after a reference "
+    + "to a file was acquired.";
+class FileFromPath {
+    constructor(input) {
+        _FileFromPath_path.set(this, void 0);
+        _FileFromPath_start.set(this, void 0);
+        __classPrivateFieldSet(this, _FileFromPath_path, input.path, "f");
+        __classPrivateFieldSet(this, _FileFromPath_start, input.start || 0, "f");
+        this.name = (0,external_path_.basename)(__classPrivateFieldGet(this, _FileFromPath_path, "f"));
+        this.size = input.size;
+        this.lastModified = input.lastModified;
+    }
+    slice(start, end) {
+        return new FileFromPath({
+            path: __classPrivateFieldGet(this, _FileFromPath_path, "f"),
+            lastModified: this.lastModified,
+            size: end - start,
+            start
+        });
+    }
+    async *stream() {
+        const { mtimeMs } = await external_fs_.promises.stat(__classPrivateFieldGet(this, _FileFromPath_path, "f"));
+        if (mtimeMs > this.lastModified) {
+            throw new node_domexception(MESSAGE, "NotReadableError");
+        }
+        if (this.size) {
+            yield* (0,external_fs_.createReadStream)(__classPrivateFieldGet(this, _FileFromPath_path, "f"), {
+                start: __classPrivateFieldGet(this, _FileFromPath_start, "f"),
+                end: __classPrivateFieldGet(this, _FileFromPath_start, "f") + this.size - 1
+            });
+        }
+    }
+    get [(_FileFromPath_path = new WeakMap(), _FileFromPath_start = new WeakMap(), Symbol.toStringTag)]() {
+        return "File";
+    }
+}
+function createFileFromPath(path, { mtimeMs, size }, filenameOrOptions, options = {}) {
+    let filename;
+    if (esm_isPlainObject(filenameOrOptions)) {
+        [options, filename] = [filenameOrOptions, undefined];
+    }
+    else {
+        filename = filenameOrOptions;
+    }
+    const file = new FileFromPath({ path, size, lastModified: mtimeMs });
+    if (!filename) {
+        filename = file.name;
+    }
+    return new File/* File */.$([file], filename, {
+        ...options, lastModified: file.lastModified
+    });
+}
+function fileFromPathSync(path, filenameOrOptions, options = {}) {
+    const stats = (0,external_fs_.statSync)(path);
+    return createFileFromPath(path, stats, filenameOrOptions, options);
+}
+async function fileFromPath(path, filenameOrOptions, options) {
+    const stats = await external_fs_.promises.stat(path);
+    return createFileFromPath(path, stats, filenameOrOptions, options);
+}
+
+
+/***/ })
+
+};
+;

--- a/dist/index.js
+++ b/dist/index.js
@@ -6072,15 +6072,6 @@ class Bot {
                     catch (parseError) {
                         (0,core.warning)(`Failed to parse response as JSON: ${parseError}`);
                         (0,core.info)(`Raw Response Text: ${responseText}`);
-                        // If parsing fails, wrap the entire response in a JSON structure
-                        responseText = JSON.stringify({
-                            reviews: [{
-                                    line_start: 0,
-                                    line_end: 0,
-                                    comment: responseText
-                                }],
-                            lgtm: false
-                        }, null, 2);
                     }
                 }
                 else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -6053,7 +6053,7 @@ class Bot {
                     responseText = responseText.trim();
                     // Check if the response starts with "reviews":
                     if (responseText.startsWith('"reviews":')) {
-                        responseText = `{${responseText}}`;
+                        responseText = `{${responseText}`;
                     }
                 }
                 else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -6045,7 +6045,7 @@ class Bot {
         if (response != null) {
             (0,core.info)(`Response type: ${typeof response}`);
             (0,core.info)(`Response keys: ${Object.keys(response).join(', ')}`);
-            (0,core.info)(`Response: ${JSON.stringify(response)}`);
+            //info(`Response: ${JSON.stringify(response)}`);
             if (Array.isArray(response.content) && response.content.length > 0) {
                 const textContent = response.content.find(item => item.type === 'text');
                 if (textContent && 'text' in textContent) {
@@ -6076,16 +6076,7 @@ class Bot {
                     }
                     catch (parseError) {
                         (0,core.warning)(`Response is not in JSON format: ${parseError}`);
-                        // If parsing fails, we'll keep the original trimmed responseText
-                        // and wrap it in a JSON structure
-                        responseText = JSON.stringify({
-                            reviews: [{
-                                    line_start: 0,
-                                    line_end: 0,
-                                    comment: responseText
-                                }],
-                            lgtm: false
-                        }, null, 2);
+                        (0,core.info)(`Raw Response Text: ${responseText}`);
                     }
                 }
                 else {
@@ -6095,12 +6086,6 @@ class Bot {
             else {
                 (0,core.warning)(`Unexpected content structure in the response: ${JSON.stringify(response.content)}`);
             }
-            if (responseText) {
-                (0,core.info)(`Response text: ${responseText.substring(0, 100)}...`); // Log the first 100 characters of the response
-            }
-            else {
-                (0,core.warning)('Response text is empty');
-            }
             newIds.parentMessageId = response.id;
         }
         else {
@@ -6109,7 +6094,7 @@ class Bot {
         if (this.options.debug) {
             (0,core.info)(`Anthropic response text: ${responseText}\n-----------`);
         }
-        return [prefix + responseText, newIds];
+        return [responseText, newIds];
     };
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -6058,7 +6058,18 @@ class Bot {
                     }
                     try {
                         // Attempt to parse the JSON content
-                        const parsedContent = JSON.parse(responseText);
+                        let parsedContent;
+                        if (responseText.startsWith('{')) {
+                            parsedContent = JSON.parse(responseText);
+                        }
+                        else {
+                            // If it doesn't start with '{', it might be a nested JSON string
+                            parsedContent = JSON.parse(JSON.parse(responseText));
+                        }
+                        // Ensure the structure is correct
+                        if (!parsedContent.reviews) {
+                            parsedContent = { reviews: parsedContent.reviews || [{ comment: responseText }], lgtm: false };
+                        }
                         responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
                     }
                     catch (parseError) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -6055,6 +6055,8 @@ class Bot {
                     if (responseText.startsWith('"reviews":')) {
                         responseText = `{${responseText}`;
                     }
+                    // Replace any control characters with their escaped Unicode representations
+                    responseText = responseText.replace(/[\u0000-\u001F\u007F-\u009F]/g, char => `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`);
                 }
                 else {
                     (0,core.warning)('No text content found in the response');

--- a/dist/index.js
+++ b/dist/index.js
@@ -6050,16 +6050,16 @@ class Bot {
                 const textContent = response.content.find(item => item.type === 'text');
                 if (textContent && 'text' in textContent) {
                     responseText = textContent.text;
-                    // Clean up the response text
-                    responseText = responseText.replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+                    // Trim leading and trailing whitespace
+                    responseText = responseText.trim();
                     try {
-                        // Parse the JSON content
+                        // Attempt to parse the JSON content
                         const parsedContent = JSON.parse(responseText);
                         responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
                     }
                     catch (parseError) {
                         (0,core.warning)(`Failed to parse response as JSON: ${parseError}`);
-                        // If parsing fails, keep the original responseText
+                        // If parsing fails, we'll keep the original trimmed responseText
                     }
                 }
                 else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -6052,6 +6052,10 @@ class Bot {
                     responseText = textContent.text;
                     // Trim leading and trailing whitespace
                     responseText = responseText.trim();
+                    // Check if the response starts with "reviews":
+                    if (responseText.startsWith('"reviews":')) {
+                        responseText = `{${responseText}}`;
+                    }
                     try {
                         // Attempt to parse the JSON content
                         const parsedContent = JSON.parse(responseText);

--- a/dist/index.js
+++ b/dist/index.js
@@ -6055,8 +6055,33 @@ class Bot {
                     if (responseText.startsWith('"reviews":')) {
                         responseText = `{${responseText}`;
                     }
-                    // Replace any control characters with their escaped Unicode representations
-                    responseText = responseText.replace(/[\u0000-\u001F\u007F-\u009F]/g, char => `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`);
+                    // Replace escaped newlines with actual newlines
+                    responseText = responseText.replace(/\\u000a/g, '\n');
+                    try {
+                        // Attempt to parse the JSON content
+                        const parsedContent = JSON.parse(responseText);
+                        // Ensure the structure is correct
+                        if (!parsedContent.reviews) {
+                            parsedContent.reviews = [];
+                        }
+                        if (typeof parsedContent.lgtm === 'undefined') {
+                            parsedContent.lgtm = false;
+                        }
+                        responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
+                    }
+                    catch (parseError) {
+                        (0,core.warning)(`Failed to parse response as JSON: ${parseError}`);
+                        (0,core.info)(`Raw Response Text: ${responseText}`);
+                        // If parsing fails, wrap the entire response in a JSON structure
+                        responseText = JSON.stringify({
+                            reviews: [{
+                                    line_start: 0,
+                                    line_end: 0,
+                                    comment: responseText
+                                }],
+                            lgtm: false
+                        }, null, 2);
+                    }
                 }
                 else {
                     (0,core.warning)('No text content found in the response');

--- a/dist/index.js
+++ b/dist/index.js
@@ -6045,36 +6045,16 @@ class Bot {
         if (response != null) {
             (0,core.info)(`Response type: ${typeof response}`);
             (0,core.info)(`Response keys: ${Object.keys(response).join(', ')}`);
-            //info(`Response: ${JSON.stringify(response)}`);
             if (Array.isArray(response.content) && response.content.length > 0) {
                 const textContent = response.content.find(item => item.type === 'text');
                 if (textContent && 'text' in textContent) {
                     responseText = textContent.text;
                     // Trim leading and trailing whitespace
                     responseText = responseText.trim();
-                    // try {
-                    //   // Attempt to parse the JSON content
-                    //   let parsedContent;
-                    //   // First, try to parse it as a regular JSON
-                    //   try {
-                    //     parsedContent = JSON.parse(responseText);
-                    //   } catch {
-                    //     // If that fails, try to parse it as a nested JSON string
-                    //     parsedContent = JSON.parse(JSON.parse(`"${responseText.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`));
-                    //   }
-                    //   // Ensure the structure is correct
-                    //   if (!parsedContent.reviews) {
-                    //     if (parsedContent.reviews) {
-                    //       parsedContent = { reviews: parsedContent.reviews, lgtm: false };
-                    //     } else {
-                    //       parsedContent = { reviews: [{ comment: responseText }], lgtm: false };
-                    //     }
-                    //   }
-                    //   responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
-                    // } catch (parseError) {
-                    //   warning(`Response is not in JSON format: ${parseError}`);
-                    //   info(`Raw Response Text: ${responseText}`);
-                    // }
+                    // Check if the response starts with "reviews":
+                    if (responseText.startsWith('"reviews":')) {
+                        responseText = `{${responseText}}`;
+                    }
                 }
                 else {
                     (0,core.warning)('No text content found in the response');

--- a/dist/index.js
+++ b/dist/index.js
@@ -6050,6 +6050,17 @@ class Bot {
                 const textContent = response.content.find(item => item.type === 'text');
                 if (textContent && 'text' in textContent) {
                     responseText = textContent.text;
+                    // Clean up the response text
+                    responseText = responseText.replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+                    try {
+                        // Parse the JSON content
+                        const parsedContent = JSON.parse(responseText);
+                        responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
+                    }
+                    catch (parseError) {
+                        (0,core.warning)(`Failed to parse response as JSON: ${parseError}`);
+                        // If parsing fails, keep the original responseText
+                    }
                 }
                 else {
                     (0,core.warning)('No text content found in the response');

--- a/dist/index.js
+++ b/dist/index.js
@@ -6058,8 +6058,17 @@ class Bot {
                         responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
                     }
                     catch (parseError) {
-                        (0,core.warning)(`Failed to parse response as JSON: ${parseError}`);
+                        (0,core.warning)(`Response is not in JSON format: ${parseError}`);
                         // If parsing fails, we'll keep the original trimmed responseText
+                        // and wrap it in a JSON structure
+                        responseText = JSON.stringify({
+                            reviews: [{
+                                    line_start: 0,
+                                    line_end: 0,
+                                    comment: responseText
+                                }],
+                            lgtm: false
+                        }, null, 2);
                     }
                 }
                 else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -6052,23 +6052,25 @@ class Bot {
                     responseText = textContent.text;
                     // Trim leading and trailing whitespace
                     responseText = responseText.trim();
-                    // Check if the response starts with "reviews":
-                    if (responseText.startsWith('"reviews":')) {
-                        responseText = `{${responseText}}`;
-                    }
                     try {
                         // Attempt to parse the JSON content
                         let parsedContent;
-                        if (responseText.startsWith('{')) {
+                        // First, try to parse it as a regular JSON
+                        try {
                             parsedContent = JSON.parse(responseText);
                         }
-                        else {
-                            // If it doesn't start with '{', it might be a nested JSON string
-                            parsedContent = JSON.parse(JSON.parse(responseText));
+                        catch {
+                            // If that fails, try to parse it as a nested JSON string
+                            parsedContent = JSON.parse(JSON.parse(`"${responseText.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`));
                         }
                         // Ensure the structure is correct
                         if (!parsedContent.reviews) {
-                            parsedContent = { reviews: parsedContent.reviews || [{ comment: responseText }], lgtm: false };
+                            if (parsedContent.reviews) {
+                                parsedContent = { reviews: parsedContent.reviews, lgtm: false };
+                            }
+                            else {
+                                parsedContent = { reviews: [{ comment: responseText }], lgtm: false };
+                            }
                         }
                         responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
                     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -6052,32 +6052,29 @@ class Bot {
                     responseText = textContent.text;
                     // Trim leading and trailing whitespace
                     responseText = responseText.trim();
-                    try {
-                        // Attempt to parse the JSON content
-                        let parsedContent;
-                        // First, try to parse it as a regular JSON
-                        try {
-                            parsedContent = JSON.parse(responseText);
-                        }
-                        catch {
-                            // If that fails, try to parse it as a nested JSON string
-                            parsedContent = JSON.parse(JSON.parse(`"${responseText.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`));
-                        }
-                        // Ensure the structure is correct
-                        if (!parsedContent.reviews) {
-                            if (parsedContent.reviews) {
-                                parsedContent = { reviews: parsedContent.reviews, lgtm: false };
-                            }
-                            else {
-                                parsedContent = { reviews: [{ comment: responseText }], lgtm: false };
-                            }
-                        }
-                        responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
-                    }
-                    catch (parseError) {
-                        (0,core.warning)(`Response is not in JSON format: ${parseError}`);
-                        (0,core.info)(`Raw Response Text: ${responseText}`);
-                    }
+                    // try {
+                    //   // Attempt to parse the JSON content
+                    //   let parsedContent;
+                    //   // First, try to parse it as a regular JSON
+                    //   try {
+                    //     parsedContent = JSON.parse(responseText);
+                    //   } catch {
+                    //     // If that fails, try to parse it as a nested JSON string
+                    //     parsedContent = JSON.parse(JSON.parse(`"${responseText.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`));
+                    //   }
+                    //   // Ensure the structure is correct
+                    //   if (!parsedContent.reviews) {
+                    //     if (parsedContent.reviews) {
+                    //       parsedContent = { reviews: parsedContent.reviews, lgtm: false };
+                    //     } else {
+                    //       parsedContent = { reviews: [{ comment: responseText }], lgtm: false };
+                    //     }
+                    //   }
+                    //   responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
+                    // } catch (parseError) {
+                    //   warning(`Response is not in JSON format: ${parseError}`);
+                    //   info(`Raw Response Text: ${responseText}`);
+                    // }
                 }
                 else {
                     (0,core.warning)('No text content found in the response');

--- a/dist/licenses.txt
+++ b/dist/licenses.txt
@@ -1,3 +1,28 @@
+formdata-node
+MIT
+The MIT License (MIT)
+
+Copyright (c) 2017-present Nick K.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
 node-fetch
 MIT
 The MIT License (MIT)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
-  "name": "openai-pr-reviewer",
+  "name": "red-rover",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "openai-pr-reviewer",
+      "name": "red-rover",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",
         "@actions/github": "^5.1.1",
+        "@anthropic-ai/sdk": "^0.29.0",
         "@dqbd/tiktoken": "^1.0.7",
         "@octokit/action": "^6.0.4",
         "@octokit/plugin-retry": "^4.1.3",
@@ -26,7 +27,6 @@
         "@typescript-eslint/eslint-plugin": "^5.59.6",
         "@typescript-eslint/parser": "^5.59.6",
         "@vercel/ncc": "^0.36.1",
-        "chatgpt": "^5.2.5",
         "eslint": "^8.41.0",
         "eslint-config-standard-with-typescript": "^36.0.0",
         "eslint-plugin-github": "^4.6.1",
@@ -196,6 +196,66 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.29.0.tgz",
+      "integrity": "sha512-3Hj28b7pAqFbGW19jXRqMvyDr09qBcL0iEuvERpbjXaqWD8dwfmMiwWreNcRvAKjeP4W4xTh0JStONvwhOTjEw==",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.55.tgz",
+      "integrity": "sha512-zzw5Vw52205Zr/nmErSEkN5FLqXPuKX/k5d1D7RKHATGqU7y6YfX9QxZraUzUrFGqH6XzOzG196BC35ltJC4Cw==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2235,14 +2295,29 @@
     "node_modules/@types/node": {
       "version": "20.4.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
-      "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw==",
-      "dev": true
+      "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw=="
     },
-    "node_modules/@types/normalize-package-data": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-      "dev": true
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -2507,6 +2582,17 @@
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
       "dev": true
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
@@ -2571,37 +2657,15 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "dev": true,
+    "node_modules/agentkeepalive": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "humanize-ms": "^1.2.1"
       },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ansi-escapes": {
@@ -2769,18 +2833,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
-    },
-    "node_modules/atomically": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.0.1.tgz",
-      "integrity": "sha512-sxBhVZUFBFhqSAsYMM3X2oaUi2NVDJ8U026FsIusM8gYXls9AYs/eXzgGrufs1Qjpkxi9zunds+75QUFz+m7UQ==",
-      "dev": true,
-      "dependencies": {
-        "stubborn-fs": "^1.2.4",
-        "when-exit": "^2.0.0"
-      }
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -2934,26 +2987,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/before-after-hook": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
@@ -3054,15 +3087,6 @@
         "semver": "^7.0.0"
       }
     },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -3135,38 +3159,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/chatgpt": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/chatgpt/-/chatgpt-5.2.5.tgz",
-      "integrity": "sha512-DNhBzPb2zTDjJADY44XfngMvsvrvHRq1md2VPXLmnKeP1UCeA1B6pV3s9ZRwlcgjVT0RyM77fRj1xj5V11Vctg==",
-      "dev": true,
-      "dependencies": {
-        "cac": "^6.7.14",
-        "conf": "^11.0.1",
-        "eventsource-parser": "^1.0.0",
-        "js-tiktoken": "^1.0.5",
-        "keyv": "^4.5.2",
-        "p-timeout": "^6.1.1",
-        "quick-lru": "^6.1.1",
-        "read-pkg-up": "^9.1.0",
-        "uuid": "^9.0.0"
-      },
-      "bin": {
-        "chatgpt": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/chatgpt/node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/ci-info": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
@@ -3237,7 +3229,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3250,28 +3241,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
-    },
-    "node_modules/conf": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-11.0.1.tgz",
-      "integrity": "sha512-WlLiQboEjKx0bYx2IIRGedBgNjLAxtwPaCSnsjWPST5xR0DB4q8lcsO/bEH9ZRYNcj63Y9vj/JG/5Fg6uWzI0Q==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^8.12.0",
-        "ajv-formats": "^2.1.1",
-        "atomically": "^2.0.0",
-        "debounce-fn": "^5.1.2",
-        "dot-prop": "^7.2.0",
-        "env-paths": "^3.0.0",
-        "json-schema-typed": "^8.0.1",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/convert-source-map": {
       "version": "1.9.0",
@@ -3343,21 +3312,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/debounce-fn": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-5.1.2.tgz",
-      "integrity": "sha512-Sr4SdOZ4vw6eQDvPYNxHogvrxmCIld/VenC5JbNrFwMiwd7lY/Z18ZFfo+EWNG4DD9nFlAujWAo/wGuOPHmy5A==",
-      "dev": true,
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/debug": {
@@ -3451,7 +3405,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3524,21 +3477,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dot-prop": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-7.2.0.tgz",
-      "integrity": "sha512-Ol/IPXUARn9CSbkrdV4VJo7uCy1I3VuSiWCaFSg+8BdUOzF9n3jefIpcgAydvUZbTdEBZs2vEiTiS9m61ssiDA==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^2.11.2"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.340",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.340.tgz",
@@ -3562,18 +3500,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
-    },
-    "node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -4517,13 +4443,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventsource-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.0.0.tgz",
-      "integrity": "sha512-9jgfSCa3dmEme2ES3mPByGXfgZ87VbP97tng1G2nWwWx6bV2nYxm2AWCrbQjXToSe+yYlqaZNtxffR9IeQr95g==",
-      "dev": true,
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "engines": {
-        "node": ">=14.18"
+        "node": ">=6"
       }
     },
     "node_modules/execa": {
@@ -4746,6 +4671,31 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/formdata-polyfill": {
@@ -5102,36 +5052,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/hosted-git-info/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/hosted-git-info/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -5184,6 +5104,14 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -8116,15 +8044,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/js-tiktoken": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.7.tgz",
-      "integrity": "sha512-biba8u/clw7iesNEWLOLwrNGoBP2lA+hTaBLs/D45pJdUPFXyxD6nhcDVtADChghv4GgyAiMKYMiRx7x6h7Biw==",
-      "dev": true,
-      "dependencies": {
-        "base64-js": "^1.5.1"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8201,28 +8120,10 @@
         "node": ">=4"
       }
     },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
-    },
-    "node_modules/json-schema-typed": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.1.tgz",
-      "integrity": "sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg==",
       "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -8254,15 +8155,6 @@
       },
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/keyv": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
-      "dev": true,
-      "dependencies": {
-        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kleur": {
@@ -8454,7 +8346,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8463,24 +8354,11 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -8569,21 +8447,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
       "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
       "dev": true
-    },
-    "node_modules/normalize-package-data": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-      "dev": true,
-      "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "is-core-module": "^2.5.0",
-        "semver": "^7.3.4",
-        "validate-npm-package-license": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -8827,18 +8690,6 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-timeout": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.1.tgz",
-      "integrity": "sha512-yqz2Wi4fiFRpMmK0L2pGAU49naSUaP23fFIQL2Y6YT+qDGPoFwpvgQM/wzc6F8JoenUkIlAFa4Ql7NguXBxI7w==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9138,113 +8989,11 @@
         }
       ]
     },
-    "node_modules/quick-lru": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
-      "integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
-    },
-    "node_modules/read-pkg": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
-      "integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
-      "dev": true,
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.1",
-        "normalize-package-data": "^3.0.2",
-        "parse-json": "^5.2.0",
-        "type-fest": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
-      "integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^6.3.0",
-        "read-pkg": "^7.1.0",
-        "type-fest": "^2.5.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^7.1.0",
-        "path-exists": "^5.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/locate-path": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
-      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^6.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-locate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
@@ -9285,15 +9034,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -9557,38 +9297,6 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-      "dev": true,
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-      "dev": true
-    },
-    "node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-license-ids": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
-      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
-      "dev": true
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -9747,12 +9455,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/stubborn-fs": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-1.2.4.tgz",
-      "integrity": "sha512-KRa4nIRJ8q6uApQbPwYZVhOof8979fw4xbajBWa5kPJFa4nyY3aFaMWVyIVCDnkNCCG/3HLipUZ4QaNlYsmX1w==",
-      "dev": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -10093,18 +9795,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typed-array-length": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
@@ -10155,6 +9845,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.0",
@@ -10246,16 +9941,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -10332,12 +10017,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/when-exit": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.0.tgz",
-      "integrity": "sha512-H85ulNwUBU1e6PGxkWUDgxnbohSXD++ah6Xw1VHAN7CtypcbZaC4aYjQ+C2PMVaDkURDuOinNAT+Lnz3utWXxQ==",
-      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "openai-pr-reviewer",
+  "name": "red-rover",
   "version": "0.0.0",
   "private": true,
-  "description": "OpenAI-based PR Reviewer and Summarizer.",
+  "description": "Anthropic-based PR Reviewer and Summarizer.",
   "main": "lib/main.js",
   "scripts": {
     "build": "cp node_modules/@dqbd/tiktoken/tiktoken_bg.wasm dist/tiktoken_bg.wasm && tsc",
@@ -14,10 +14,6 @@
     "test": "jest",
     "all": "npm run build && npm run format && npm run lint && npm run package && npm test"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/fluxninja/openai-pr-reviewer.git"
-  },
   "keywords": [
     "actions",
     "node",
@@ -27,6 +23,7 @@
   "dependencies": {
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.1.1",
+    "@anthropic-ai/sdk": "^0.29.0",
     "@dqbd/tiktoken": "^1.0.7",
     "@octokit/action": "^6.0.4",
     "@octokit/plugin-retry": "^4.1.3",
@@ -42,7 +39,6 @@
     "@typescript-eslint/eslint-plugin": "^5.59.6",
     "@typescript-eslint/parser": "^5.59.6",
     "@vercel/ncc": "^0.36.1",
-    "chatgpt": "^5.2.5",
     "eslint": "^8.41.0",
     "eslint-config-standard-with-typescript": "^36.0.0",
     "eslint-plugin-github": "^4.6.1",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -106,7 +106,19 @@ export class Bot {
           
           try {
             // Attempt to parse the JSON content
-            const parsedContent = JSON.parse(responseText);
+            let parsedContent;
+            if (responseText.startsWith('{')) {
+              parsedContent = JSON.parse(responseText);
+            } else {
+              // If it doesn't start with '{', it might be a nested JSON string
+              parsedContent = JSON.parse(JSON.parse(responseText));
+            }
+            
+            // Ensure the structure is correct
+            if (!parsedContent.reviews) {
+              parsedContent = { reviews: parsedContent.reviews || [{ comment: responseText }], lgtm: false };
+            }
+            
             responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
           } catch (parseError) {
             warning(`Response is not in JSON format: ${parseError}`);

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -89,7 +89,6 @@ export class Bot {
     if (response != null) {
       info(`Response type: ${typeof response}`);
       info(`Response keys: ${Object.keys(response).join(', ')}`);
-      //info(`Response: ${JSON.stringify(response)}`);
       
       if (Array.isArray(response.content) && response.content.length > 0) {
         const textContent = response.content.find(item => item.type === 'text');
@@ -99,32 +98,10 @@ export class Bot {
           // Trim leading and trailing whitespace
           responseText = responseText.trim();
           
-          // try {
-          //   // Attempt to parse the JSON content
-          //   let parsedContent;
-            
-          //   // First, try to parse it as a regular JSON
-          //   try {
-          //     parsedContent = JSON.parse(responseText);
-          //   } catch {
-          //     // If that fails, try to parse it as a nested JSON string
-          //     parsedContent = JSON.parse(JSON.parse(`"${responseText.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`));
-          //   }
-            
-          //   // Ensure the structure is correct
-          //   if (!parsedContent.reviews) {
-          //     if (parsedContent.reviews) {
-          //       parsedContent = { reviews: parsedContent.reviews, lgtm: false };
-          //     } else {
-          //       parsedContent = { reviews: [{ comment: responseText }], lgtm: false };
-          //     }
-          //   }
-            
-          //   responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
-          // } catch (parseError) {
-          //   warning(`Response is not in JSON format: ${parseError}`);
-          //   info(`Raw Response Text: ${responseText}`);
-          // }
+          // Check if the response starts with "reviews":
+          if (responseText.startsWith('"reviews":')) {
+            responseText = `{${responseText}}`;
+          }
         } else {
           warning('No text content found in the response');
         }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -55,18 +55,18 @@ export class Bot {
         max_tokens: 4096,
         messages: [
           {
-            role: 'user' as 'user',
+            role: 'user',
             content: message
           },
           ...(prefix
             ? [
                 {
-                  role: 'assistant' as 'assistant',
+                  role: 'assistant',
                   content: prefix
-                }
+                } as const
               ]
             : [])
-        ]
+        ],
       };
       response = await pRetry(
         () =>
@@ -92,13 +92,19 @@ export class Bot {
       
       if (Array.isArray(response.content) && response.content.length > 0) {
         const textContent = response.content.find(item => item.type === 'text');
-        if (textContent && typeof textContent.text === 'string') {
+        if (textContent && 'text' in textContent) {
           responseText = textContent.text;
         } else {
           warning('No text content found in the response');
         }
       } else {
-        warning('Unexpected content structure in the response');
+        warning(`Unexpected content structure in the response: ${JSON.stringify(response.content)}`);
+      }
+
+      if (responseText) {
+        info(`Response text: ${responseText.substring(0, 100)}...`); // Log the first 100 characters of the response
+      } else {
+        warning('Response text is empty');
       }
 
       newIds.parentMessageId = response.id;

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -102,6 +102,10 @@ export class Bot {
           if (responseText.startsWith('"reviews":')) {
             responseText = `{${responseText}`;
           }
+          // Replace any control characters with their escaped Unicode representations
+          responseText = responseText.replace(/[\u0000-\u001F\u007F-\u009F]/g, 
+            char => `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`);
+
         } else {
           warning('No text content found in the response');
         }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -100,7 +100,7 @@ export class Bot {
           
           // Check if the response starts with "reviews":
           if (responseText.startsWith('"reviews":')) {
-            responseText = `{${responseText}}`;
+            responseText = `{${responseText}`;
           }
         } else {
           warning('No text content found in the response');

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -95,6 +95,18 @@ export class Bot {
         const textContent = response.content.find(item => item.type === 'text');
         if (textContent && 'text' in textContent) {
           responseText = textContent.text;
+          
+          // Clean up the response text
+          responseText = responseText.replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+          
+          try {
+            // Parse the JSON content
+            const parsedContent = JSON.parse(responseText);
+            responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
+          } catch (parseError) {
+            warning(`Failed to parse response as JSON: ${parseError}`);
+            // If parsing fails, keep the original responseText
+          }
         } else {
           warning('No text content found in the response');
         }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -89,7 +89,7 @@ export class Bot {
     if (response != null) {
       info(`Response type: ${typeof response}`);
       info(`Response keys: ${Object.keys(response).join(', ')}`);
-      info(`Response: ${JSON.stringify(response)}`);
+      //info(`Response: ${JSON.stringify(response)}`);
       
       if (Array.isArray(response.content) && response.content.length > 0) {
         const textContent = response.content.find(item => item.type === 'text');
@@ -123,28 +123,13 @@ export class Bot {
             responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
           } catch (parseError) {
             warning(`Response is not in JSON format: ${parseError}`);
-            // If parsing fails, we'll keep the original trimmed responseText
-            // and wrap it in a JSON structure
-            responseText = JSON.stringify({
-              reviews: [{
-                line_start: 0,
-                line_end: 0,
-                comment: responseText
-              }],
-              lgtm: false
-            }, null, 2);
+            info(`Raw Response Text: ${responseText}`);
           }
         } else {
           warning('No text content found in the response');
         }
       } else {
         warning(`Unexpected content structure in the response: ${JSON.stringify(response.content)}`);
-      }
-
-      if (responseText) {
-        info(`Response text: ${responseText.substring(0, 100)}...`); // Log the first 100 characters of the response
-      } else {
-        warning('Response text is empty');
       }
 
       newIds.parentMessageId = response.id;
@@ -156,6 +141,6 @@ export class Bot {
       info(`Anthropic response text: ${responseText}\n-----------`);
     }
 
-    return [prefix + responseText, newIds]
+    return [responseText, newIds]
   }
 }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -99,32 +99,32 @@ export class Bot {
           // Trim leading and trailing whitespace
           responseText = responseText.trim();
           
-          try {
-            // Attempt to parse the JSON content
-            let parsedContent;
+          // try {
+          //   // Attempt to parse the JSON content
+          //   let parsedContent;
             
-            // First, try to parse it as a regular JSON
-            try {
-              parsedContent = JSON.parse(responseText);
-            } catch {
-              // If that fails, try to parse it as a nested JSON string
-              parsedContent = JSON.parse(JSON.parse(`"${responseText.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`));
-            }
+          //   // First, try to parse it as a regular JSON
+          //   try {
+          //     parsedContent = JSON.parse(responseText);
+          //   } catch {
+          //     // If that fails, try to parse it as a nested JSON string
+          //     parsedContent = JSON.parse(JSON.parse(`"${responseText.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`));
+          //   }
             
-            // Ensure the structure is correct
-            if (!parsedContent.reviews) {
-              if (parsedContent.reviews) {
-                parsedContent = { reviews: parsedContent.reviews, lgtm: false };
-              } else {
-                parsedContent = { reviews: [{ comment: responseText }], lgtm: false };
-              }
-            }
+          //   // Ensure the structure is correct
+          //   if (!parsedContent.reviews) {
+          //     if (parsedContent.reviews) {
+          //       parsedContent = { reviews: parsedContent.reviews, lgtm: false };
+          //     } else {
+          //       parsedContent = { reviews: [{ comment: responseText }], lgtm: false };
+          //     }
+          //   }
             
-            responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
-          } catch (parseError) {
-            warning(`Response is not in JSON format: ${parseError}`);
-            info(`Raw Response Text: ${responseText}`);
-          }
+          //   responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
+          // } catch (parseError) {
+          //   warning(`Response is not in JSON format: ${parseError}`);
+          //   info(`Raw Response Text: ${responseText}`);
+          // }
         } else {
           warning('No text content found in the response');
         }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -99,6 +99,11 @@ export class Bot {
           // Trim leading and trailing whitespace
           responseText = responseText.trim();
           
+          // Check if the response starts with "reviews":
+          if (responseText.startsWith('"reviews":')) {
+            responseText = `{${responseText}}`;
+          }
+          
           try {
             // Attempt to parse the JSON content
             const parsedContent = JSON.parse(responseText);

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -122,15 +122,6 @@ export class Bot {
           } catch (parseError) {
             warning(`Failed to parse response as JSON: ${parseError}`);
             info(`Raw Response Text: ${responseText}`);
-            // If parsing fails, wrap the entire response in a JSON structure
-            responseText = JSON.stringify({
-              reviews: [{
-                line_start: 0,
-                line_end: 0,
-                comment: responseText
-              }],
-              lgtm: false
-            }, null, 2);
           }
         } else {
           warning('No text content found in the response');

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -89,6 +89,7 @@ export class Bot {
     if (response != null) {
       info(`Response type: ${typeof response}`);
       info(`Response keys: ${Object.keys(response).join(', ')}`);
+      info(`Response: ${JSON.stringify(response)}`);
       
       if (Array.isArray(response.content) && response.content.length > 0) {
         const textContent = response.content.find(item => item.type === 'text');

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -96,16 +96,16 @@ export class Bot {
         if (textContent && 'text' in textContent) {
           responseText = textContent.text;
           
-          // Clean up the response text
-          responseText = responseText.replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+          // Trim leading and trailing whitespace
+          responseText = responseText.trim();
           
           try {
-            // Parse the JSON content
+            // Attempt to parse the JSON content
             const parsedContent = JSON.parse(responseText);
             responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
           } catch (parseError) {
             warning(`Failed to parse response as JSON: ${parseError}`);
-            // If parsing fails, keep the original responseText
+            // If parsing fails, we'll keep the original trimmed responseText
           }
         } else {
           warning('No text content found in the response');

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -99,24 +99,25 @@ export class Bot {
           // Trim leading and trailing whitespace
           responseText = responseText.trim();
           
-          // Check if the response starts with "reviews":
-          if (responseText.startsWith('"reviews":')) {
-            responseText = `{${responseText}}`;
-          }
-          
           try {
             // Attempt to parse the JSON content
             let parsedContent;
-            if (responseText.startsWith('{')) {
+            
+            // First, try to parse it as a regular JSON
+            try {
               parsedContent = JSON.parse(responseText);
-            } else {
-              // If it doesn't start with '{', it might be a nested JSON string
-              parsedContent = JSON.parse(JSON.parse(responseText));
+            } catch {
+              // If that fails, try to parse it as a nested JSON string
+              parsedContent = JSON.parse(JSON.parse(`"${responseText.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`));
             }
             
             // Ensure the structure is correct
             if (!parsedContent.reviews) {
-              parsedContent = { reviews: parsedContent.reviews || [{ comment: responseText }], lgtm: false };
+              if (parsedContent.reviews) {
+                parsedContent = { reviews: parsedContent.reviews, lgtm: false };
+              } else {
+                parsedContent = { reviews: [{ comment: responseText }], lgtm: false };
+              }
             }
             
             responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -104,8 +104,17 @@ export class Bot {
             const parsedContent = JSON.parse(responseText);
             responseText = JSON.stringify(parsedContent, null, 2); // Pretty print the JSON
           } catch (parseError) {
-            warning(`Failed to parse response as JSON: ${parseError}`);
+            warning(`Response is not in JSON format: ${parseError}`);
             // If parsing fails, we'll keep the original trimmed responseText
+            // and wrap it in a JSON structure
+            responseText = JSON.stringify({
+              reviews: [{
+                line_start: 0,
+                line_end: 0,
+                comment: responseText
+              }],
+              lgtm: false
+            }, null, 2);
           }
         } else {
           warning('No text content found in the response');

--- a/src/commenter.ts
+++ b/src/commenter.ts
@@ -40,6 +40,8 @@ export const SHORT_SUMMARY_END_TAG = `--><!-- end of auto-generated comment: sho
 export const COMMIT_ID_START_TAG = '<!-- commit_ids_reviewed_start -->'
 export const COMMIT_ID_END_TAG = '<!-- commit_ids_reviewed_end -->'
 
+const SELF_LOGIN = 'github-actions[bot]'
+
 export class Commenter {
   /**
    * @param mode Can be "create", "replace". Default is "replace".
@@ -491,16 +493,21 @@ ${chain}
     return allChains
   }
 
+  getRole(login: string) {
+    if (login === SELF_LOGIN) return '\nA (You): '
+    return `\nH (@${login}):`
+  }
+
   async composeCommentChain(reviewComments: any[], topLevelComment: any) {
     const conversationChain = reviewComments
       .filter((cmt: any) => cmt.in_reply_to_id === topLevelComment.id)
-      .map((cmt: any) => `${cmt.user.login}: ${cmt.body}`)
+      .map((cmt: any) => `${this.getRole(cmt.user.login)} ${cmt.body}`)
 
     conversationChain.unshift(
-      `${topLevelComment.user.login}: ${topLevelComment.body}`
+      `${this.getRole(topLevelComment.user.login)} ${topLevelComment.body}`
     )
 
-    return conversationChain.join('\n---\n')
+    return `${conversationChain.join('\n')}`
   }
 
   async getCommentChain(pullNumber: number, comment: any) {

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -4,6 +4,7 @@ export class Inputs {
   description: string
   rawSummary: string
   shortSummary: string
+  reviewFileDiff: string
   filename: string
   fileContent: string
   fileDiff: string
@@ -18,6 +19,7 @@ export class Inputs {
     description = 'no description provided',
     rawSummary = '',
     shortSummary = '',
+    reviewFileDiff = '',
     filename = '',
     fileContent = 'file contents cannot be provided',
     fileDiff = 'file diff cannot be provided',
@@ -31,6 +33,7 @@ export class Inputs {
     this.description = description
     this.rawSummary = rawSummary
     this.shortSummary = shortSummary
+    this.reviewFileDiff = reviewFileDiff
     this.filename = filename
     this.fileContent = fileContent
     this.fileDiff = fileDiff
@@ -47,6 +50,7 @@ export class Inputs {
       this.description,
       this.rawSummary,
       this.shortSummary,
+      this.reviewFileDiff,
       this.filename,
       this.fileContent,
       this.fileDiff,
@@ -75,6 +79,9 @@ export class Inputs {
     }
     if (this.shortSummary) {
       content = content.replace('$short_summary', this.shortSummary)
+    }
+    if (this.reviewFileDiff) {
+      content = content.replace('$review_file_diff', this.reviewFileDiff)
     }
     if (this.filename) {
       content = content.replace('$filename', this.filename)

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -2,31 +2,18 @@ export class TokenLimits {
   maxTokens: number
   requestTokens: number
   responseTokens: number
-  knowledgeCutOff: string
 
-  constructor(model = 'gpt-4o-mini') {
-    this.knowledgeCutOff = '2021-09-01'
-    if (model === 'gpt-4-32k') {
-      this.maxTokens = 32600
+  constructor(model = 'anthropic.claude-instant-v1') {
+    if (model === 'anthropic.claude-instant-v1') {
+      this.maxTokens = 100_000
       this.responseTokens = 4000
-    } else if (model === 'gpt-3.5-turbo-16k') {
-      this.maxTokens = 16300
+    } else if (model === 'anthropic.claude-v2') {
+      this.maxTokens = 100_000
       this.responseTokens = 3000
-    } else if (model === 'gpt-4') {
-      this.maxTokens = 8192
-      this.responseTokens = 8192
-    } else if (model === 'gpt-4o') {
-      this.maxTokens = 128000
-      this.responseTokens = 4096
-    } else if (model === 'o1-mini') {
-      this.maxTokens = 128000
-      this.responseTokens = 65536
-    } else if (model === 'o1-preview') {
-      this.maxTokens = 128000
-      this.responseTokens = 32768
     } else {
-      this.maxTokens = 128000
-      this.responseTokens = 16384
+      // The latest models usually have this level of limits.
+      this.maxTokens = 200_000
+      this.responseTokens = 4096
     }
     // provide some margin for the request tokens
     this.requestTokens = this.maxTokens - this.responseTokens - 100

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import {
   warning
 } from '@actions/core'
 import {Bot} from './bot'
-import {OpenAIOptions, Options} from './options'
+import {AnthropicOptions, Options} from './options'
 import {Prompts} from './prompts'
 import {codeReview} from './review'
 import {handleReviewComment} from './review-comment'
@@ -22,14 +22,14 @@ async function run(): Promise<void> {
     getBooleanInput('review_comment_lgtm'),
     getMultilineInput('path_filters'),
     getInput('system_message'),
-    getInput('openai_light_model'),
-    getInput('openai_heavy_model'),
-    getInput('openai_model_temperature'),
-    getInput('openai_retries'),
-    getInput('openai_timeout_ms'),
-    getInput('openai_concurrency_limit'),
+    getInput('review_file_diff'),
+    getInput('anthropic_light_model'),
+    getInput('anthropic_heavy_model'),
+    getInput('anthropic_model_temperature'),
+    getInput('anthropic_retries'),
+    getInput('anthropic_timeout_ms'),
+    getInput('anthropic_concurrency_limit'),
     getInput('github_concurrency_limit'),
-    getInput('openai_base_url'),
     getInput('language')
   )
 
@@ -49,11 +49,11 @@ async function run(): Promise<void> {
   try {
     lightBot = new Bot(
       options,
-      new OpenAIOptions(options.openaiLightModel, options.lightTokenLimits)
+      new AnthropicOptions(options.anthropicLightModel, options.lightTokenLimits)
     )
   } catch (e: any) {
     warning(
-      `Skipped: failed to create summary bot, please check your openai_api_key: ${e}, backtrace: ${e.stack}`
+      `Skipped: failed to create summary bot, please check your anthropic_api_key: ${e}, backtrace: ${e.stack}`
     )
     return
   }
@@ -62,11 +62,11 @@ async function run(): Promise<void> {
   try {
     heavyBot = new Bot(
       options,
-      new OpenAIOptions(options.openaiHeavyModel, options.heavyTokenLimits)
+      new AnthropicOptions(options.anthropicHeavyModel, options.heavyTokenLimits)
     )
   } catch (e: any) {
     warning(
-      `Skipped: failed to create review bot, please check your openai_api_key: ${e}, backtrace: ${e.stack}`
+      `Skipped: failed to create review bot, please check your anthropic_api_key: ${e}, backtrace: ${e.stack}`
     )
     return
   }

--- a/src/options.ts
+++ b/src/options.ts
@@ -12,16 +12,16 @@ export class Options {
   reviewCommentLGTM: boolean
   pathFilters: PathFilter
   systemMessage: string
-  openaiLightModel: string
-  openaiHeavyModel: string
-  openaiModelTemperature: number
-  openaiRetries: number
-  openaiTimeoutMS: number
-  openaiConcurrencyLimit: number
+  reviewFileDiff: string
+  anthropicLightModel: string
+  anthropicHeavyModel: string
+  anthropicModelTemperature: number
+  anthropicRetries: number
+  anthropicTimeoutMS: number
+  anthropicConcurrencyLimit: number
   githubConcurrencyLimit: number
   lightTokenLimits: TokenLimits
   heavyTokenLimits: TokenLimits
-  apiBaseUrl: string
   language: string
 
   constructor(
@@ -34,14 +34,14 @@ export class Options {
     reviewCommentLGTM = false,
     pathFilters: string[] | null = null,
     systemMessage = '',
-    openaiLightModel = 'gpt-4o-mini',
-    openaiHeavyModel = 'gpt-4o',
-    openaiModelTemperature = '0.0',
-    openaiRetries = '3',
-    openaiTimeoutMS = '120000',
-    openaiConcurrencyLimit = '6',
+    reviewFileDiff = '',
+    anthropicLightModel: string,
+    anthropicHeavyModel: string,
+    anthropicModelTemperature = '0.0',
+    anthropicRetries = '3',
+    anthropicTimeoutMS = '120000',
+    anthropicConcurrencyLimit = '6',
     githubConcurrencyLimit = '6',
-    apiBaseUrl = 'https://api.openai.com/v1',
     language = 'en-US'
   ) {
     this.debug = debug
@@ -53,16 +53,16 @@ export class Options {
     this.reviewCommentLGTM = reviewCommentLGTM
     this.pathFilters = new PathFilter(pathFilters)
     this.systemMessage = systemMessage
-    this.openaiLightModel = openaiLightModel
-    this.openaiHeavyModel = openaiHeavyModel
-    this.openaiModelTemperature = parseFloat(openaiModelTemperature)
-    this.openaiRetries = parseInt(openaiRetries)
-    this.openaiTimeoutMS = parseInt(openaiTimeoutMS)
-    this.openaiConcurrencyLimit = parseInt(openaiConcurrencyLimit)
+    this.reviewFileDiff = reviewFileDiff
+    this.anthropicLightModel = anthropicLightModel
+    this.anthropicHeavyModel = anthropicHeavyModel
+    this.anthropicModelTemperature = parseFloat(anthropicModelTemperature)
+    this.anthropicRetries = parseInt(anthropicRetries)
+    this.anthropicTimeoutMS = parseInt(anthropicTimeoutMS)
+    this.anthropicConcurrencyLimit = parseInt(anthropicConcurrencyLimit)
     this.githubConcurrencyLimit = parseInt(githubConcurrencyLimit)
-    this.lightTokenLimits = new TokenLimits(openaiLightModel)
-    this.heavyTokenLimits = new TokenLimits(openaiHeavyModel)
-    this.apiBaseUrl = apiBaseUrl
+    this.lightTokenLimits = new TokenLimits(anthropicLightModel)
+    this.heavyTokenLimits = new TokenLimits(anthropicHeavyModel)
     this.language = language
   }
 
@@ -77,16 +77,16 @@ export class Options {
     info(`review_comment_lgtm: ${this.reviewCommentLGTM}`)
     info(`path_filters: ${this.pathFilters}`)
     info(`system_message: ${this.systemMessage}`)
-    info(`openai_light_model: ${this.openaiLightModel}`)
-    info(`openai_heavy_model: ${this.openaiHeavyModel}`)
-    info(`openai_model_temperature: ${this.openaiModelTemperature}`)
-    info(`openai_retries: ${this.openaiRetries}`)
-    info(`openai_timeout_ms: ${this.openaiTimeoutMS}`)
-    info(`openai_concurrency_limit: ${this.openaiConcurrencyLimit}`)
+    info(`review_file_diff: ${this.reviewFileDiff}`)
+    info(`anthropic_light_model: ${this.anthropicLightModel}`)
+    info(`anthropic_heavy_model: ${this.anthropicHeavyModel}`)
+    info(`anthropic_model_temperature: ${this.anthropicModelTemperature}`)
+    info(`anthropic_retries: ${this.anthropicRetries}`)
+    info(`anthropic_timeout_ms: ${this.anthropicTimeoutMS}`)
+    info(`anthropic_concurrency_limit: ${this.anthropicConcurrencyLimit}`)
     info(`github_concurrency_limit: ${this.githubConcurrencyLimit}`)
     info(`summary_token_limits: ${this.lightTokenLimits.string()}`)
     info(`review_token_limits: ${this.heavyTokenLimits.string()}`)
-    info(`api_base_url: ${this.apiBaseUrl}`)
     info(`language: ${this.language}`)
   }
 
@@ -116,6 +116,11 @@ export class PathFilter {
     }
   }
 
+  /**
+   * Returns true if the file should be processed, not ignored.
+   * If there is any inclusion rule set, a file is included when it matches any of inclusion rule.
+   * If there is no inclusion rule set, a file is included when it does not matches any of exclusion rule.
+   */
   check(path: string): boolean {
     if (this.rules.length === 0) {
       return true
@@ -142,11 +147,14 @@ export class PathFilter {
   }
 }
 
-export class OpenAIOptions {
+export class AnthropicOptions {
   model: string
   tokenLimits: TokenLimits
 
-  constructor(model = 'gpt-4o-mini', tokenLimits: TokenLimits | null = null) {
+  constructor(
+    model = 'anthropic.claude-instant-v1',
+    tokenLimits: TokenLimits | null = null
+  ) {
     this.model = model
     if (tokenLimits != null) {
       this.tokenLimits = tokenLimits

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -6,53 +6,38 @@ export class Prompts {
   poemEnabled: boolean
   poem: string
 
-  summarizeFileDiff = `## GitHub PR Title
+  summarizeFileDiff = `
+I would like you to succinctly summarize the Pull Request within 100 words.
+The Pull Request is described with <title>, <description>, and <diff> tags.
+If applicable, your summary should include a note about alterations to the signatures of exported functions, global data structures and variables, and any changes that might affect the external interface or behavior of the code.
 
-\`$title\` 
+<pull_request_title>
+$title 
+</pull_request_title>
 
-## Description
-
-\`\`\`
+<pull_request_description>
 $description
-\`\`\`
+</pull_request_description>
 
-## Diff
-
-\`\`\`diff
+<pull_request_diff>
 $file_diff
-\`\`\`
-
-## Instructions
-
-I would like you to succinctly summarize the diff within 100 words.
-If applicable, your summary should include a note about alterations 
-to the signatures of exported functions, global data structures and 
-variables, and any changes that might affect the external interface or 
-behavior of the code.
+</pull_request_diff>
 `
-  triageFileDiff = `Below the summary, I would also like you to triage the diff as \`NEEDS_REVIEW\` or 
-\`APPROVED\` based on the following criteria:
+  triageFileDiff = `Below the summary, I would also like you to triage the diff as \`NEEDS_REVIEW\` or \`APPROVED\` based on the following criteria:
 
-- If the diff involves any modifications to the logic or functionality, even if they 
-  seem minor, triage it as \`NEEDS_REVIEW\`. This includes changes to control structures, 
-  function calls, or variable assignments that might impact the behavior of the code.
-- If the diff only contains very minor changes that don't affect the code logic, such as 
-  fixing typos, formatting, or renaming variables for clarity, triage it as \`APPROVED\`.
+- If the diff involves any modifications to the logic or functionality, even if they seem minor, triage it as \`NEEDS_REVIEW\`. This includes changes to control structures, function calls, or variable assignments that might impact the behavior of the code.
+- If the diff only contains very minor changes that don't affect the code logic, such as fixing typos, formatting, or renaming variables for clarity, triage it as \`APPROVED\`.
 
-Please evaluate the diff thoroughly and take into account factors such as the number of 
-lines changed, the potential impact on the overall system, and the likelihood of 
-introducing new bugs or security vulnerabilities. 
+Please evaluate the diff thoroughly and take into account factors such as the number of lines changed, the potential impact on the overall system, and the likelihood of introducing new bugs or security vulnerabilities. 
 When in doubt, always err on the side of caution and triage the diff as \`NEEDS_REVIEW\`.
 
 You must strictly follow the format below for triaging the diff:
 [TRIAGE]: <NEEDS_REVIEW or APPROVED>
 
 Important:
-- In your summary do not mention that the file needs a through review or caution about
-  potential issues.
+- In your summary do not mention that the file needs a through review or caution about potential issues.
 - Do not provide any reasoning why you triaged the diff as \`NEEDS_REVIEW\` or \`APPROVED\`.
-- Do not mention that these changes affect the logic or functionality of the code in 
-  the summary. You must only use the triage status format above to indicate that.
+- Do not mention that these changes affect the logic or functionality of the code in the summary. You must only use the triage status format above to indicate that.
 `
   lessVerboseTriageFileDiff = `Below the summary, I would also like you to triage the diff as \`NEEDS_REVIEW\` or 
   \`APPROVED\` based on the following criteria:
@@ -76,27 +61,26 @@ Important:
   - Do not mention that these changes affect the logic or functionality of the code in 
     the summary. You must only use the triage status format above to indicate that.
 `
-  summarizeChangesets = `Provided below are changesets in this pull request. Changesets 
-are in chronlogical order and new changesets are appended to the
-end of the list. The format consists of filename(s) and the summary 
+
+  summarizeChangesets = `Provided below (<changeSet> tag) are changesets in this pull request.
+Changesets are in chronlogical order and new changesets are appended to the end of the list. The format consists of filename(s) and the summary 
 of changes for those files. There is a separator between each changeset.
-Your task is to deduplicate and group together files with
-related/similar changes into a single changeset. Respond with the updated 
-changesets using the same format as the input. 
+Your task is to deduplicate and group together files with related/similar changes into a single changeset. Respond with the updated changesets using the same format as the input. 
 
+<changeSet>
 $raw_summary
+</changeSet>
 `
 
-  summarizePrefix = `Here is the summary of changes you have generated for files:
-      \`\`\`
-      $raw_summary
-      \`\`\`
+  summarizePrefix = `Below <summary> tag is the summary of changes you have generated for files:
+<summary>
+$raw_summary
+</summary>
 
 `
 
-  summarizeShort = `Your task is to provide a concise summary of the changes. This 
-summary will be used as a prompt while reviewing each file and must be very clear for 
-the AI bot to understand. 
+  summarizeShort = `Your task is to provide a concise summary of the changes.
+This summary will be used as a prompt while reviewing each file and must be very clear for the AI bot to understand. 
 
 Instructions:
 
@@ -107,48 +91,38 @@ Instructions:
 - The summary should not exceed 500 words.
 `
 
-  reviewFileDiff = `## GitHub PR Title
+  reviewFileDiff = `
+$system_message
 
-\`$title\` 
+<pull_request_title>
+$title 
+</pull_request_title>
 
-## Description
-
-\`\`\`
+<pull_request_description>
 $description
-\`\`\`
+</pull_request_description>
 
-## Summary of changes
-
-\`\`\`
+<pull_request_changes>
 $short_summary
-\`\`\`
+</pull_request_changes>
 
 ## IMPORTANT Instructions
 
-Input: New hunks annotated with line numbers and old hunks (replaced code). Hunks represent incomplete code fragments.
-Additional Context: PR title, description, summaries and comment chains.
+Input: New hunks annotated with line numbers and old hunks (replaced code). Hunks represent incomplete code fragments. Example input is in <example_input> tag below.
+Additional Context: <pull_request_title>, <pull_request_description>, <pull_request_changes> and comment chains. 
 Task: Review new hunks for substantive issues using provided context and respond with comments if necessary.
-Output: Review comments in markdown with exact line number ranges in new hunks. Start and end line numbers must be within the same hunk. For single-line comments, start=end line number. Must use example response format below.
+Output: Review comments in markdown with exact line number ranges in new hunks. Start and end line numbers must be within the same hunk. For single-line comments, start=end line number. Must use JSON output format in <example_output> tag below.
 Use fenced code blocks using the relevant language identifier where applicable.
 Don't annotate code snippets with line numbers. Format and indent code correctly.
 Do not use \`suggestion\` code blocks.
 For fixes, use \`diff\` code blocks, marking changes with \`+\` or \`-\`. The line number range for comments with fix snippets must exactly match the range to replace in the new hunk.
 
-- Do NOT provide general feedback, summaries, explanations of changes, or praises 
-  for making good additions. 
-- Focus solely on offering specific, objective insights based on the 
-  given context and refrain from making broad comments about potential impacts on 
-  the system or question intentions behind the changes.
+$review_file_diff
 
-If there are no issues found on a line range, you MUST respond with the 
-text \`LGTM!\` for that line range in the review section. 
+If there are no issues found on a line range, you MUST respond with the flag "lgtm": true in the response JSON. Don't stop with unfinished JSON. You MUST output a complete and proper JSON that can be parsed.
 
-## Example
-
-### Example changes
-
----new_hunk---
-\`\`\`
+<example_input>
+<new_hunk>
   z = x / y
     return z
 
@@ -156,15 +130,15 @@ text \`LGTM!\` for that line range in the review section.
 21:     z = x + y
 22:     retrn z
 23: 
+24: 
 24: def multiply(x, y):
 25:     return x * y
 
 def subtract(x, y):
   z = x - y
-\`\`\`
+</new_hunk>
   
----old_hunk---
-\`\`\`
+<old_hunk>
   z = x / y
     return z
 
@@ -173,92 +147,88 @@ def add(x, y):
 
 def subtract(x, y):
     z = x - y
-\`\`\`
+</old_hunk>
 
----comment_chains---
+<comment_chains>
 \`\`\`
 Please review this change.
 \`\`\`
+</comment_chains>
+</example_input>
 
----end_change_section---
-
-### Example response
-
-22-22:
-There's a syntax error in the add function.
-\`\`\`diff
--    retrn z
-+    return z
-\`\`\`
----
-24-25:
-LGTM!
----
+<example_output>
+{
+  "reviews": [
+    {
+      "line_start": 22,
+      "line_end": 22,
+      "comment": "There's a syntax error in the add function.\\n  -    retrn z\\n  +    return z",
+    },
+    {
+      "line_start": 23,
+      "line_end": 24,
+      "comment": "There's a redundant new line here. It should be only one.",
+    }
+  ],
+  "lgtm": false
+}
+</example_output>
 
 ## Changes made to \`$filename\` for your review
 
 $patches
 `
 
-  comment = `A comment was made on a GitHub PR review for a 
-diff hunk on a file - \`$filename\`. I would like you to follow 
-the instructions in that comment. 
+  comment = `
+$system_message
 
-## GitHub PR Title
+A comment was made on a GitHub PR review for a diff hunk on a file - \`$filename\`. I would like you to follow the instructions in that comment. 
 
-\`$title\`
+<pull_request_title>
+$title 
+</pull_request_title>
 
-## Description
-
-\`\`\`
+<pull_request_description>
 $description
-\`\`\`
+</pull_request_description>
 
-## Summary generated by the AI bot
-
-\`\`\`
+<short_summary>
 $short_summary
-\`\`\`
+</short_summary>
 
-## Entire diff
-
-\`\`\`diff
+<entire_diff>
 $file_diff
-\`\`\`
+</entire_diff>
 
-## Diff being commented on
+Here is the diff that is now comment on.
 
-\`\`\`diff
+<partial_diff>
 $diff
-\`\`\`
+<partial_diff>
 
 ## Instructions
 
-Please reply directly to the new comment (instead of suggesting 
-a reply) and your reply will be posted as-is.
+Please reply directly to the new comment (instead of suggesting a reply) and your reply will be posted as-is.
 
 If the comment contains instructions/requests for you, please comply. 
-For example, if the comment is asking you to generate documentation 
-comments on the code, in your reply please generate the required code.
+For example, if the comment is asking you to generate documentation comments on the code, in your reply please generate the required code.
 
-In your reply, please make sure to begin the reply by tagging the user 
-with "@user".
+In your reply, please make sure to begin the reply by tagging the user with "@user".
 
-## Comment format
+<example>
+@username You are right. Thanks for the explanation!
+</example>
 
-\`user: comment\`
+Here is the comment history YOU and the users had. Note that H=human and A=you(assistant).
 
-## Comment chain (including the new comment)
-
-\`\`\`
+<history>
 $comment_chain
-\`\`\`
+</history>
 
-## The comment/request that you need to directly reply to
-
-\`\`\`
+This is the comment/request that you need to directly reply to
+<comment>
 $comment
-\`\`\`
+</comment>
 `
 
   constructor(

--- a/src/review-comment.ts
+++ b/src/review-comment.ts
@@ -172,7 +172,11 @@ export const handleReviewComment = async (
         }
       }
 
-      const [reply] = await heavyBot.chat(prompts.renderComment(inputs), {})
+      inputs.commentChain = inputs.commentChain
+        .replace(COMMENT_TAG, '')
+        .replace(COMMENT_REPLY_TAG, '')
+
+      const [reply] = await heavyBot.chat(prompts.renderComment(inputs))
 
       await commenter.reviewCommentReply(pullNumber, topLevelComment, reply)
     }


### PR DESCRIPTION















<!-- This is an auto-generated comment: release notes by RedRover -->
### Summary by RedRover

Here’s a draft Pull Request description using the provided “context7” summary:

Title  
Rebrand to “red-rover” / Swap OpenAI → Anthropic (Claude)  

Description  
This PR rebrands our GitHub Action and package from “openai-pr-reviewer” to “red-rover” and replaces all OpenAI integrations with Anthropic’s Claude models. It updates workflows, action metadata, code, prompts, README, licensing, and dependencies accordingly.

---

## What changed?  

1. Project metadata & licensing  
   • Renamed project from `openai-pr-reviewer` → `red-rover`  
   • Appended “tmokmss (2023)” to the MIT header in LICENSE  

2. CI workflow & Action manifest  
   • `.github/workflows/redrover_review.yml`  
     – Uses `RedVentures/red-rover@anthropic`  
     – Swaps `OPENAI_API_KEY` → `ANTHROPIC_API_KEY`  
     – Removes OpenAI models/inputs, enables debug mode  
   • `action.yml`  
     – Renamed inputs (`openai_*` → `anthropic_*`), added `review_file_diff` & `bot_icon`  
     – Commented out leftover OpenAI entries (`system_message`, `openai_heavy_model`)  
     – Updated descriptions, prompts, and default values  

3. Documentation & examples  
   • `README.md`  
     – All usage, examples and environment variables now reference Anthropic (claude-instant-v1, claude-v2)  
     – Updated SDK instructions, cost/disclaimer, debug guidance  

4. Dependencies & packaging  
   • `package.json` & `package-lock.json`  
     – Renamed package, updated metadata, removed `chatgpt` dependency  
     – Added `@anthropic-ai/sdk@0.29.0` and sub-deps  

5. Core source changes  
   • `src/*` files renamed types and options from OpenAI → Anthropic  
   • main.ts  
     – Instantiates `Bot` with `AnthropicOptions`, enforces `ANTHROPIC_API_KEY`  
     – Wires in new `review_file_diff` input  
   • inputs.ts & options.ts  
     – Support include/exclude path filters  
     – Define Claude token limits (100 000 total; 4 000/3 000 response)  
   • bot.ts  
     – Replaces OpenAI client with Anthropic SDK (`createMessage`) and retry logic  
   • review.ts & review-comment.ts  
     – Wrap diffs in XML tags, remove OpenAI concurrency, parse JSON from Claude  
     – Strip tags before rendering comments  
   • prompts.ts  
     – All templates refactored to XML-style tags, new JSON schema examples, new `reviewFileDiff` & `comment` templates  
   • commenter.ts  
     – Adds `SELF_LOGIN` logic to prefix comments as “A (You):” or “H (@username):”  

---

## How to test  

1. Set `ANTHROPIC_API_KEY` in your environment or repository secrets.  
2. Create or update a PR in a test repo to trigger the `red-rover_review.yml` workflow.  
3. Inspect the generated review comments; verify that:  
   - All OpenAI references are gone  
   - The bot uses `claude-instant-v1` or `claude-v2` as configured  
   - Path filters (include/exclude) behave as expected  
   - The JSON schema in prompts is respected  

---

## Notes  

- We no longer support OpenAI keys or models—this is a one-way migration.  
- Claude’s token limits have been baked into defaults. Adjust in your workflow inputs if needed.  
- Legacy users must update their secrets, inputs, and marketplace workflow references.  

---

Please review and let me know if anything’s missing or if you spot residual OpenAI references.
<!-- end of auto-generated comment: release notes by RedRover -->